### PR TITLE
Add PostgreSQL schema and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+__pycache__/

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,3 +17,23 @@ uvicorn app.main:app --reload
 ```
 
 The API provides JWT authentication, rate limiting, error handling middleware, and Redis caching for feed responses. OpenAPI/Swagger documentation is available at `/docs` when the server is running.
+
+## Database Schema
+
+The backend uses PostgreSQL with SQLAlchemy and Alembic for migrations. The core tables are:
+
+- **users** – application users (`id`, `username`).
+- **films** – films indexed by Kinopoisk (`id`, `kinopoisk_id`, `metadata`).
+- **clips** – user submitted film clips (`id`, `film_id`, `user_id`, `title`). Clip IDs are unique.
+- **bookmarks** – mapping of users to bookmarked clips (`id`, `user_id`, `clip_id`).
+- **likes** – mapping of users to liked clips (`id`, `user_id`, `clip_id`).
+- **comments** – user comments on clips (`id`, `user_id`, `clip_id`, `text`).
+
+Foreign keys connect clips to films and users, and link interactions back to the originating user and clip.
+
+Run migrations and seed data:
+
+```bash
+alembic upgrade head
+python app/seed.py
+```

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/filmclips
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s: %(message)s

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,27 @@
+"""Database configuration and session management."""
+
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+# Default to a local Postgres instance. Can be overridden via environment
+# variable when deploying.
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/filmclips",
+)
+
+engine = create_engine(DATABASE_URL, future=True, echo=False)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+Base = declarative_base()
+
+
+def get_db():
+    """Yield a database session for request scope."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,9 @@ from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
 import redis.asyncio as redis
 import json
+from sqlalchemy import text
+
+from .db import engine
 
 app = FastAPI(title="FilmClips API")
 
@@ -32,6 +35,9 @@ async def startup() -> None:
         "redis://localhost", encoding="utf-8", decode_responses=True
     )
     await FastAPILimiter.init(app.state.redis)
+    # Ensure database connection is available
+    with engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
 
 
 @app.on_event("shutdown")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,88 @@
+"""ORM models for FilmClips."""
+
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .db import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, nullable=False)
+
+    clips = relationship("Clip", back_populates="user")
+    bookmarks = relationship("Bookmark", back_populates="user")
+    likes = relationship("Like", back_populates="user")
+    comments = relationship("Comment", back_populates="user")
+
+
+class Film(Base):
+    __tablename__ = "films"
+
+    id = Column(Integer, primary_key=True, index=True)
+    kinopoisk_id = Column(Integer, nullable=False)
+    data = Column("metadata", JSON)
+
+    clips = relationship("Clip", back_populates="film")
+
+
+class Clip(Base):
+    __tablename__ = "clips"
+
+    id = Column(Integer, primary_key=True, index=True)
+    film_id = Column(Integer, ForeignKey("films.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    title = Column(String)
+
+    film = relationship("Film", back_populates="clips")
+    user = relationship("User", back_populates="clips")
+    bookmarks = relationship("Bookmark", back_populates="clip")
+    likes = relationship("Like", back_populates="clip")
+    comments = relationship("Comment", back_populates="clip")
+
+    __table_args__ = (UniqueConstraint("id", name="uq_clip_id"),)
+
+
+class Bookmark(Base):
+    __tablename__ = "bookmarks"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    clip_id = Column(Integer, ForeignKey("clips.id"), nullable=False)
+
+    user = relationship("User", back_populates="bookmarks")
+    clip = relationship("Clip", back_populates="bookmarks")
+
+
+class Like(Base):
+    __tablename__ = "likes"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    clip_id = Column(Integer, ForeignKey("clips.id"), nullable=False)
+
+    user = relationship("User", back_populates="likes")
+    clip = relationship("Clip", back_populates="likes")
+
+
+class Comment(Base):
+    __tablename__ = "comments"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    clip_id = Column(Integer, ForeignKey("clips.id"), nullable=False)
+    text = Column(Text, nullable=False)
+
+    user = relationship("User", back_populates="comments")
+    clip = relationship("Clip", back_populates="comments")
+

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,0 +1,40 @@
+"""Seed initial data for testing."""
+
+from .db import SessionLocal
+from . import models
+
+
+def seed() -> None:
+    db = SessionLocal()
+    try:
+        # Users
+        alice = models.User(username="alice")
+        bob = models.User(username="bob")
+        db.add_all([alice, bob])
+        db.flush()
+
+        # Films
+        film1 = models.Film(kinopoisk_id=100, data={"title": "Film 100"})
+        film2 = models.Film(kinopoisk_id=200, data={"title": "Film 200"})
+        db.add_all([film1, film2])
+        db.flush()
+
+        # Clips
+        clip1 = models.Clip(film=film1, user=alice, title="Clip 1")
+        clip2 = models.Clip(film=film2, user=bob, title="Clip 2")
+        db.add_all([clip1, clip2])
+        db.flush()
+
+        # Interactions
+        db.add(models.Bookmark(user=alice, clip=clip2))
+        db.add(models.Like(user=bob, clip=clip1))
+        db.add(models.Comment(user=bob, clip=clip1, text="Great clip!"))
+
+        db.commit()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()
+

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: filmclips
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,53 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+import os
+import sys
+
+# Ensure app package is on path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from app.db import Base, DATABASE_URL  # noqa: E402
+from app import models  # noqa: F401,E402
+
+config = context.config
+config.set_main_option('sqlalchemy.url', DATABASE_URL)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/versions/0001_initial.py
+++ b/backend/migrations/versions/0001_initial.py
@@ -1,0 +1,69 @@
+"""initial tables
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-05-10 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('username', sa.String(), nullable=False, unique=True),
+    )
+
+    op.create_table(
+        'films',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('kinopoisk_id', sa.Integer, nullable=False),
+        sa.Column('metadata', sa.JSON(), nullable=True),
+    )
+
+    op.create_table(
+        'clips',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('film_id', sa.Integer, sa.ForeignKey('films.id'), nullable=False),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('title', sa.String(), nullable=True),
+        sa.UniqueConstraint('id', name='uq_clip_id'),
+    )
+
+    op.create_table(
+        'bookmarks',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('clip_id', sa.Integer, sa.ForeignKey('clips.id'), nullable=False),
+    )
+
+    op.create_table(
+        'likes',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('clip_id', sa.Integer, sa.ForeignKey('clips.id'), nullable=False),
+    )
+
+    op.create_table(
+        'comments',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('clip_id', sa.Integer, sa.ForeignKey('clips.id'), nullable=False),
+        sa.Column('text', sa.Text(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('comments')
+    op.drop_table('likes')
+    op.drop_table('bookmarks')
+    op.drop_table('clips')
+    op.drop_table('films')
+    op.drop_table('users')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 pyjwt
 redis
 fastapi-limiter
+SQLAlchemy
+psycopg2-binary
+alembic


### PR DESCRIPTION
## Summary
- configure SQLAlchemy connection and models
- add Alembic migrations for users, films, clips, bookmarks, likes, comments
- seed database with sample data and document schema

## Testing
- `npm test`
- `npm run lint`
- `alembic upgrade head`
- `python -m app.seed`
- `psql -h localhost -U postgres -d filmclips -c "SELECT * FROM users;"`


------
https://chatgpt.com/codex/tasks/task_e_689f95bf30b8832d993c096f2fbeef10