### PR TITLE
feat: replace mock feed with backend API

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,51 @@
+export const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+let token: string | null = null;
+
+export async function authenticate(
+  username: string = 'guest',
+): Promise<string> {
+  const res = await fetch(`${API_URL}/auth`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username }),
+  });
+  const data = await res.json();
+  token = data.access_token;
+  return token;
+}
+
+function authHeader() {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function getFeed(): Promise<any[]> {
+  const res = await fetch(`${API_URL}/feed`, { headers: { ...authHeader() } });
+  const data = await res.json();
+  return (data.items || []) as any[];
+}
+
+export async function likeClip(clipId: string) {
+  await fetch(`${API_URL}/like?clip_id=${clipId}`, {
+    method: 'POST',
+    headers: { ...authHeader() },
+  });
+}
+
+export async function bookmarkClip(clipId: string) {
+  await fetch(`${API_URL}/bookmark?clip_id=${clipId}`, {
+    method: 'POST',
+    headers: { ...authHeader() },
+  });
+}
+
+export async function commentClip(clipId: string, text: string) {
+  await fetch(
+    `${API_URL}/comment?clip_id=${clipId}&text=${encodeURIComponent(text)}`,
+    {
+      method: 'POST',
+      headers: { ...authHeader() },
+    },
+  );
+}

--- a/frontend/src/app/feed/page.tsx
+++ b/frontend/src/app/feed/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { CLIPS, GENRES } from '@/data/mock';
 import { useApp } from '@/context/BookmarksContext';
+import { getFeed } from '@/api';
+import { Clip } from '@/types/clip';
 
 export default function FeedPage() {
   const {
@@ -15,13 +16,23 @@ export default function FeedPage() {
     toggleBookmark,
     addComment,
   } = useApp();
-  const list = CLIPS.filter((c) =>
+  const [clips, setClips] = useState<Clip[]>([]);
+  const list = clips.filter((c) =>
     genres.length ? c.genres.some((g) => genres.includes(g)) : true,
   );
-  const [currentId, setCurrentId] = useState(list[0]?.id);
+  const [currentId, setCurrentId] = useState<string | undefined>();
   const [showCommentsFor, setShowCommentsFor] = useState<string | null>(null);
   const [commentText, setCommentText] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    getFeed()
+      .then((items: Clip[]) => {
+        setClips(items);
+        if (items.length) setCurrentId(items[0].id);
+      })
+      .catch(() => setClips([]));
+  }, []);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -72,10 +83,7 @@ export default function FeedPage() {
             <div className="info">
               <div className="title">{clip.filmTitle}</div>
               <div className="meta">
-                {clip.year} •{' '}
-                {clip.genres
-                  .map((g) => GENRES.find((x) => x.id === g)?.name || g)
-                  .join(' • ')}
+                {clip.year} • {clip.genres.join(' • ')}
               </div>
               <div className="logline">{clip.logline}</div>
               <div className="tags">


### PR DESCRIPTION
## Summary
- fetch feed from backend instead of static CLIPS array
- authenticate and forward likes, bookmarks and comments to API
- add minimal API client handling JWT token

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fb149cef4832da04e283270c77d29