### PR TITLE
Ensure backend dependencies install before dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@
 
 ```bash
 npm install
+npm run setup-backend
 npm run dev
 ```
 
-Скрипт поднимает одновременно FastAPI-сервер (`http://localhost:8000`) и фронтенд Next.js (`http://localhost:3000`).
+Команда `npm run setup-backend` устанавливает Python-зависимости для FastAPI. После этого `npm run dev` поднимает одновременно FastAPI-сервер (`http://localhost:8000`) и фронтенд Next.js (`http://localhost:3000`).
 
 ## Разработка
 Отдельные пакеты можно запускать напрямую:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "echo 'No tests yet'",
     "lint": "eslint . --config shared/.eslintrc.cjs",
     "format": "prettier . --config shared/.prettierrc.json --write",
-    "dev": "concurrently \"uvicorn backend.app.main:app --reload\" \"npm run --workspace frontend dev\"",
+    "setup-backend": "python -m pip install -r backend/requirements.txt",
+    "dev": "npm run setup-backend && concurrently \"uvicorn backend.app.main:app --reload\" \"npm run --workspace frontend dev\"",
     "start": "concurrently \"uvicorn backend.app.main:app\" \"npm run --workspace frontend start\""
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add an npm script that installs the backend Python requirements and call it from the dev workflow
- document the backend dependency installation step in the root README so developers run it before npm run dev

## Testing
- npm run dev *(fails when the backend cannot reach Redis, but uvicorn is present)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b4c65bf4832da81e4b9d059c5a96